### PR TITLE
added highlighting for cxx flags

### DIFF
--- a/CMake.tmLanguage
+++ b/CMake.tmLanguage
@@ -135,6 +135,14 @@
 			<key>name</key>
 			<string>invalid.deprecated.source.cmake</string>
 		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Compiler Flags</string>
+			<key>match</key>
+			<string>\b(?i:(CMAKE_)?(CXX_FLAGS|CMAKE_CXX_FLAGS_DEBUG|CMAKE_CXX_FLAGS_MINSIZEREL|CMAKE_CXX_FLAGS_RELEASE|CMAKE_CXX_FLAGS_RELWITHDEBINFO))\b</string>
+			<key>name</key>
+			<string>variable.source.cmake</string>
+		</dict>
 	</array>
 	<key>scopeName</key>
 	<string>source.cmake</string>


### PR DESCRIPTION
The following example will be highlighted correctly.

```
set(CMAKE_CXX_FLAGS                "-Wall -std=c++11")
set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")
set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
```
