### PR TITLE
Add config header syntaxes

### DIFF
--- a/CMake C Header.sublime-syntax
+++ b/CMake C Header.sublime-syntax
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: CMake C Header
+file_extensions: [h.in]
+scope: source.cmake.config.c
+variables:
+  identifier: '\b[[:alpha:]_][[:alnum:]_]*\b'
+contexts:
+  main:
+    - match: ""
+      push: "Packages/C++/C.sublime-syntax"
+      with_prototype:
+        - match: \$\{
+          scope: keyword.other.block.start.cmake
+          push:
+            - meta_include_prototype: true
+            - meta_scope: variable.cmake
+            - match: \}
+              scope: keyword.other.block.end.cmake
+              pop: true
+        - match: \@
+          scope: keyword.other.block.start.cmake
+          push:
+            - meta_include_prototype: true
+            - meta_scope: variable.cmake
+            - match: \@
+              scope: keyword.other.block.end.cmake
+              pop: true
+        - match: ^\s*(\#\s*cmakedefine)\b
+          captures:
+            1: meta.preprocessor.macro.c keyword.control.import.cmakedefine.c
+          push:
+            - meta_content_scope: meta.preprocessor.macro.c
+            - include: scope:source.c#preprocessor-line-continuation
+            - include: scope:source.c#preprocessor-line-ending
+            - include: scope:source.c#preprocessor-comments
+            - match: '{{identifier}}'
+              scope: entity.name.variable.cmake
+              pop: true

--- a/CMake C++ Header.sublime-syntax
+++ b/CMake C++ Header.sublime-syntax
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: CMake C++ Header
+file_extensions: [hh.in, hpp.in, hxx.in, h++.in]
+scope: source.cmake.config.c++
+variables:
+  identifier: '\b[[:alpha:]_][[:alnum:]_]*\b'
+contexts:
+  main:
+    - match: ""
+      push: "Packages/C++/C++.sublime-syntax"
+      with_prototype:
+        - match: \$\{
+          scope: keyword.other.block.start.cmake
+          push:
+            - meta_include_prototype: true
+            - meta_scope: variable.cmake
+            - match: \}
+              scope: keyword.other.block.end.cmake
+              pop: true
+        - match: \@
+          scope: keyword.other.block.start.cmake
+          push:
+            - meta_include_prototype: true
+            - meta_scope: variable.cmake
+            - match: \@
+              scope: keyword.other.block.end.cmake
+              pop: true
+        - match: ^\s*(\#\s*cmakedefine)\b
+          captures:
+            1: meta.preprocessor.macro.c++ keyword.control.import.cmakedefine.c++
+          push:
+            - meta_content_scope: meta.preprocessor.macro.c++
+            - include: scope:source.c++#preprocessor-line-continuation
+            - include: scope:source.c++#preprocessor-line-ending
+            - include: scope:source.c++#preprocessor-comments
+            - match: '{{identifier}}'
+              scope: entity.name.variable.cmake
+              pop: true

--- a/syntax_test_.h.in
+++ b/syntax_test_.h.in
@@ -1,0 +1,16 @@
+// SYNTAX TEST "Packages/Sublime-CMakeLists/CMake C Header.sublime-syntax"
+
+#define X ${Y}
+//<- meta.preprocessor.macro keyword.control.import.define - keyword.control.import.cmakedefine
+//        ^^ meta.preprocessor.macro variable.cmake keyword.other.block.start.cmake
+//          ^ meta.preprocessor.macro variable.cmake
+//           ^ meta.preprocessor.macro variable.cmake keyword.other.block.end.cmake
+
+#define X @Y@
+//<- meta.preprocessor.macro keyword.control.import.define - keyword.control.import.cmakedefine
+//        ^ meta.preprocessor.macro variable.cmake keyword.other.block.start.cmake
+//         ^ meta.preprocessor.macro variable.cmake
+//          ^ meta.preprocessor.macro variable.cmake keyword.other.block.end.cmake
+
+#cmakedefine Z
+//<- meta.preprocessor.macro keyword.control.import.cmakedefine

--- a/syntax_test_.hpp.in
+++ b/syntax_test_.hpp.in
@@ -1,0 +1,16 @@
+// SYNTAX TEST "Packages/Sublime-CMakeLists/CMake C++ Header.sublime-syntax"
+
+#define X ${Y}
+//<- meta.preprocessor.macro keyword.control.import.define - keyword.control.import.cmakedefine
+//        ^^ meta.preprocessor.macro variable.cmake keyword.other.block.start.cmake
+//          ^ meta.preprocessor.macro variable.cmake
+//           ^ meta.preprocessor.macro variable.cmake keyword.other.block.end.cmake
+
+#define X @Y@
+//<- meta.preprocessor.macro keyword.control.import.define - keyword.control.import.cmakedefine
+//        ^ meta.preprocessor.macro variable.cmake keyword.other.block.start.cmake
+//         ^ meta.preprocessor.macro variable.cmake
+//          ^ meta.preprocessor.macro variable.cmake keyword.other.block.end.cmake
+
+#cmakedefine Z
+//<- meta.preprocessor.macro keyword.control.import.cmakedefine


### PR DESCRIPTION
When you have a config header defined in CMake, say
```cmake
configure_file(config.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/config.hpp")
target_include_directories(my_target "${CMAKE_CURRENT_BINAR_DIR}")
```
then things like

    #cmakedefine BLAH

are not highlighted in the config.hpp.in file. This pull requests adds highlighting for files that end with `h.in` (for C config headers) or that end with `hh.in`, `hpp.in`, `h++.in` (for C++).

The syntax just pushes the C (or C++) syntax on the stack, except that it also highlights the `#cmakedefine` directive, and it also highlights make variable substitutions like `${FOO}` and `@FOO@` inside the config header files.