### PR TITLE
Add basic snippets and key-bindings

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -11,7 +11,7 @@
         "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.cmake" }
+            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call" }
         ]
     },
     {
@@ -24,7 +24,7 @@
         "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.cmake" }
+            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call" }
         ]
     },
     {
@@ -37,7 +37,7 @@
         "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.cmake" }
+            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call" }
         ]
     }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,43 @@
+[
+    {
+        // Wrap selection as a variable substitution.
+        // Keeps the variable selected so that you can also press double-quotes
+        // (") and it will wrap it in double quotes.
+        "keys": ["$"], "command": "insert_snippet",
+        "args":
+        {
+            "contents": "${1:\\${$SELECTION\\}}"
+        },
+        "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.cmake" }
+        ]
+    },
+    {
+        // Wrap selection as a generator expression with an argument selection.
+        "keys": ["<"], "command": "insert_snippet",
+        "args":
+        {
+            "contents": "<$SELECTION:${1:argument}>"
+        },
+        "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.cmake" }
+        ]
+    },
+    {
+        // Wrap selection as a generator expression without an argument.
+        "keys": [">"], "command": "insert_snippet",
+        "args":
+        {
+            "contents": "<$SELECTION>"
+        },
+        "context":
+        [
+            { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
+            { "key": "selector", "operator": "equal", "operand": "source.cmake" }
+        ]
+    }
+]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -11,7 +11,7 @@
         "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call" }
+            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call.arguments" }
         ]
     },
     {
@@ -24,7 +24,7 @@
         "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call" }
+            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call.arguments" }
         ]
     },
     {
@@ -37,7 +37,7 @@
         "context":
         [
             { "key": "selection_empty", "operator": "equal", "operand": false, "match_all": true },
-            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call" }
+            { "key": "selector", "operator": "equal", "operand": "source.cmake meta.function-call.arguments" }
         ]
     }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -16,7 +16,7 @@
     },
     {
         // Wrap selection as a generator expression with an argument selection.
-        "keys": ["<"], "command": "insert_snippet",
+        "keys": ["ctrl+shift+,"], "command": "insert_snippet",
         "args":
         {
             "contents": "<$SELECTION:${1:argument}>"
@@ -29,7 +29,7 @@
     },
     {
         // Wrap selection as a generator expression without an argument.
-        "keys": [">"], "command": "insert_snippet",
+        "keys": ["ctrl+shift+."], "command": "insert_snippet",
         "args":
         {
             "contents": "<$SELECTION>"

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -19,7 +19,7 @@
         "keys": ["ctrl+shift+,"], "command": "insert_snippet",
         "args":
         {
-            "contents": "<$SELECTION:${1:argument}>"
+            "contents": "\\$<$SELECTION:${1:argument}>"
         },
         "context":
         [
@@ -32,7 +32,7 @@
         "keys": ["ctrl+shift+."], "command": "insert_snippet",
         "args":
         {
-            "contents": "<$SELECTION>"
+            "contents": "\\$<$SELECTION>"
         },
         "context":
         [

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@
 * `while`
 
 If an argument to a command is optional, it is selectable when you tab through
-the snippet, and you can then press escape to remove the optional argument.
+the snippet, and you can then press backspace to remove the optional argument.
 
 ## Available Key Bindings
 
-* Select a word, and type the dollar-sign character (`$`) to wrap the selection
+* Select a word, and press <kbd>$</kbd> to wrap the selection
   as a [variable substitution][3]. The newly inserted text will stay selected, 
-  so that you can press the double-quotes character (`"`) to enclose the 
+  so that you can press the double-quotes character <kbd>"</kbd> to enclose the 
   selection in double-qoutes too. Press tab to get out of the selection if you 
-  don't want  double-quotes.
-* Select a word, and type the less-than character (`<`) to wrap the selection
-  as a [generator expression][2] with an argument.
-* Select a word, and type the greater-than character (`>`) to wrap the selection
-  as a [generator expression][2] without an argument.
+  don't want double-quotes.
+* Select a word, and press <kbd>ctrl</kbd><kbd>shift</kbd><kbd>,</kbd> to wrap 
+  the selection as a [generator expression][2] with an argument.
+* Select a word, and press <kbd>ctrl</kbd><kbd>shift</kbd><kbd>.</kbd> to wrap
+  the selection as a [generator expression][2] without an argument.
 
 [1]: https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html
 [2]: https://cmake.org/cmake/help/v3.0/manual/cmake-generator-expressions.7.html

--- a/README.md
+++ b/README.md
@@ -4,6 +4,34 @@
 
 * Simple auto-indentation support.
 * Syntax highlighting, based on [CMake 3.0][1].
+* Basic snippets.
+* Basic keybindings.
+
+## Available Snippets
+
+* `cmake_minimum_required`
+* `foreach`
+* `if`
+* `option`
+* `project`
+* `set`
+* `while`
+
+If an argument to a command is optional, it is selectable when you tab through
+the snippet, and you can then press escape to remove the optional argument.
+
+## Available Key Bindings
+
+* Select a word, and type the dollar-sign character (`$`) to wrap the selection
+  as a [variable substitution][3]. The newly inserted text will stay selected, 
+  so that you can press the double-quotes character (`"`) to enclose the 
+  selection in double-qoutes too. Press tab to get out of the selection if you 
+  don't want  double-quotes.
+* Select a word, and type the less-than character (`<`) to wrap the selection
+  as a [generator expression][2] with an argument.
+* Select a word, and type the greater-than character (`>`) to wrap the selection
+  as a [generator expression][2] without an argument.
 
 [1]: https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html
-
+[2]: https://cmake.org/cmake/help/v3.0/manual/cmake-generator-expressions.7.html
+[3]: https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#variable-references

--- a/Snippets/cmake_minimum_required.sublime-snippet
+++ b/Snippets/cmake_minimum_required.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<description>command</description>
+	<content><![CDATA[cmake_minimum_required(VERSION ${1:3.0.0} ${2:FATAL_ERROR})]]></content>
+	<tabTrigger>cmake_minimum_required</tabTrigger>
+	<scope>source.cmake</scope>
+</snippet>

--- a/Snippets/cmake_minimum_required.sublime-snippet
+++ b/Snippets/cmake_minimum_required.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[cmake_minimum_required(VERSION ${1:3.0.0} ${2:FATAL_ERROR})]]></content>
 	<tabTrigger>cmake_minimum_required</tabTrigger>
-	<scope>source.cmake - meta.function-call - string - comment</scope>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>

--- a/Snippets/cmake_minimum_required.sublime-snippet
+++ b/Snippets/cmake_minimum_required.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[cmake_minimum_required(VERSION ${1:3.0.0} ${2:FATAL_ERROR})]]></content>
 	<tabTrigger>cmake_minimum_required</tabTrigger>
-	<scope>source.cmake</scope>
+	<scope>source.cmake - meta.function-call - string - comment</scope>
 </snippet>

--- a/Snippets/foreach.sublime-snippet
+++ b/Snippets/foreach.sublime-snippet
@@ -4,5 +4,5 @@
 	$0
 endforeach(${1:item})]]></content>
 	<tabTrigger>foreach</tabTrigger>
-	<scope>source.cmake</scope>
+	<scope>source.cmake - meta.function-call - string - comment</scope>
 </snippet>

--- a/Snippets/foreach.sublime-snippet
+++ b/Snippets/foreach.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<description>control flow</description>
+	<content><![CDATA[foreach(${1:item} ${2:items})
+	$0
+endforeach(${1:item})]]></content>
+	<tabTrigger>foreach</tabTrigger>
+	<scope>source.cmake</scope>
+</snippet>

--- a/Snippets/foreach.sublime-snippet
+++ b/Snippets/foreach.sublime-snippet
@@ -4,5 +4,5 @@
 	$0
 endforeach(${1:item})]]></content>
 	<tabTrigger>foreach</tabTrigger>
-	<scope>source.cmake - meta.function-call - string - comment</scope>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>

--- a/Snippets/if.sublime-snippet
+++ b/Snippets/if.sublime-snippet
@@ -4,5 +4,5 @@
 	$0
 endif(${1:predicate})]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>source.cmake - meta.function-call - string - comment</scope>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>

--- a/Snippets/if.sublime-snippet
+++ b/Snippets/if.sublime-snippet
@@ -4,5 +4,5 @@
 	$0
 endif(${1:predicate})]]></content>
 	<tabTrigger>if</tabTrigger>
-	<scope>source.cmake</scope>
+	<scope>source.cmake - meta.function-call - string - comment</scope>
 </snippet>

--- a/Snippets/if.sublime-snippet
+++ b/Snippets/if.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<description>control flow</description>
+	<content><![CDATA[if(${1:predicate})
+	$0
+endif(${1:predicate})]]></content>
+	<tabTrigger>if</tabTrigger>
+	<scope>source.cmake</scope>
+</snippet>

--- a/Snippets/option.sublime-snippet
+++ b/Snippets/option.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[option(${1:option_variable} "${2:help string describing ${1:option_variable}}" ${3:initial value of ${1:option_variable}})]]></content>
 	<tabTrigger>option</tabTrigger>
-	<scope>source.cmake - meta.function-call - string - comment</scope>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>

--- a/Snippets/option.sublime-snippet
+++ b/Snippets/option.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[option(${1:option_variable} "${2:help string describing ${1:option_variable}}" ${3:initial value of ${1:option_variable}})]]></content>
 	<tabTrigger>option</tabTrigger>
-	<scope>source.cmake</scope>
+	<scope>source.cmake - meta.function-call - string - comment</scope>
 </snippet>

--- a/Snippets/option.sublime-snippet
+++ b/Snippets/option.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<description>command</description>
+	<content><![CDATA[option(${1:option_variable} "${2:help string describing ${1:option_variable}}" ${3:initial value of ${1:option_variable}})]]></content>
+	<tabTrigger>option</tabTrigger>
+	<scope>source.cmake</scope>
+</snippet>

--- a/Snippets/project.sublime-snippet
+++ b/Snippets/project.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<description>command</description>
+	<content><![CDATA[project(${1:name of this project} ${2:VERSION ${3:0.1.0}} ${4:LANGUAGES ${5:CXX and/or C}})]]></content>
+	<tabTrigger>project</tabTrigger>
+	<scope>source.cmake</scope>
+</snippet>

--- a/Snippets/project.sublime-snippet
+++ b/Snippets/project.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[project(${1:name of this project} ${2:VERSION ${3:0.1.0}} ${4:LANGUAGES ${5:CXX and/or C}})]]></content>
 	<tabTrigger>project</tabTrigger>
-	<scope>source.cmake - meta.function-call - string - comment</scope>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>

--- a/Snippets/project.sublime-snippet
+++ b/Snippets/project.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[project(${1:name of this project} ${2:VERSION ${3:0.1.0}} ${4:LANGUAGES ${5:CXX and/or C}})]]></content>
 	<tabTrigger>project</tabTrigger>
-	<scope>source.cmake</scope>
+	<scope>source.cmake - meta.function-call - string - comment</scope>
 </snippet>

--- a/Snippets/set.sublime-snippet
+++ b/Snippets/set.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[set(${1:variable} ${2:value} ${3:CACHE} ${4:type_of_${1:variable}} ${5:"${6:Documentation for ${1:variable}}"} ${7:FORCE} ${8:PARENT_SCOPE})]]></content>
 	<tabTrigger>set</tabTrigger>
-	<scope>source.cmake</scope>
+	<scope>source.cmake - meta.function-call - string - comment</scope>
 </snippet>

--- a/Snippets/set.sublime-snippet
+++ b/Snippets/set.sublime-snippet
@@ -2,5 +2,5 @@
 	<description>command</description>
 	<content><![CDATA[set(${1:variable} ${2:value} ${3:CACHE} ${4:type_of_${1:variable}} ${5:"${6:Documentation for ${1:variable}}"} ${7:FORCE} ${8:PARENT_SCOPE})]]></content>
 	<tabTrigger>set</tabTrigger>
-	<scope>source.cmake - meta.function-call - string - comment</scope>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>

--- a/Snippets/set.sublime-snippet
+++ b/Snippets/set.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+	<description>command</description>
+	<content><![CDATA[set(${1:variable} ${2:value} ${3:CACHE} ${4:type_of_${1:variable}} ${5:"${6:Documentation for ${1:variable}}"} ${7:FORCE} ${8:PARENT_SCOPE})]]></content>
+	<tabTrigger>set</tabTrigger>
+	<scope>source.cmake</scope>
+</snippet>

--- a/Snippets/while.sublime-snippet
+++ b/Snippets/while.sublime-snippet
@@ -4,5 +4,5 @@
 	$0
 endwhile(${1:predicate})]]></content>
 	<tabTrigger>while</tabTrigger>
-	<scope>source.cmake</scope>
+	<scope>source.cmake - meta.function-call - string - comment</scope>
 </snippet>

--- a/Snippets/while.sublime-snippet
+++ b/Snippets/while.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<description>control flow</description>
+	<content><![CDATA[while(${1:predicate})
+	$0
+endwhile(${1:predicate})]]></content>
+	<tabTrigger>while</tabTrigger>
+	<scope>source.cmake</scope>
+</snippet>

--- a/Snippets/while.sublime-snippet
+++ b/Snippets/while.sublime-snippet
@@ -4,5 +4,5 @@
 	$0
 endwhile(${1:predicate})]]></content>
 	<tabTrigger>while</tabTrigger>
-	<scope>source.cmake - meta.function-call - string - comment</scope>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>


### PR DESCRIPTION
This pull request adds basic snippets and key-bindings.

## Snippets
* cmake_minimum_required
* foreach
* if
* option
* project
* set
* while

## Key-bindings
* When you select a word and press `$` it will wrap it as a variable substitution
* When you select a word and press `<` it will wrap it as a generator-expression with argument
* When you select a word and press `>` it will wrap it as a generator-expression without argument