### PR TITLE
Add CMakeCache syntax highlighting

### DIFF
--- a/CMakeCache.sublime-syntax
+++ b/CMakeCache.sublime-syntax
@@ -1,0 +1,54 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: CMakeCache
+file_extensions: [CMakeCache.txt]
+first_line_match: "# This is the CMakeCache file."
+scope: source.cmakecache
+
+variables:
+  identifier: '[a-zA-Z0-9\-_:\\/ .]+'
+
+contexts:
+  main:
+    - include: comments
+    - include: key-value-pair
+
+  comments:
+    - match: \/\/
+      scope: punctuation.definition.comment.cmakecache
+      push:
+        - meta_scope: comment.line.double-slash.doc.cmakecache
+        - match: $
+          pop: true
+    - match: \#
+      scope: punctuation.definition.comment.cmakecache
+      push:
+        - meta_scope: comment.line.number-sign.cmakecache
+        - match: $
+          pop: true
+
+  key-value-pair:
+    - match: ^(\w|-)+
+      scope: variable.parameter.cmakecache
+      set: expect-type
+    - match: .
+      scope: invalid.illegal
+
+  expect-type:
+    - match: ':'
+      scope: punctuation.separator.cmakecache
+    - match: '{{identifier}}'
+      scope: storage.type.cmakecache
+      set: expect-value
+    - match: .
+      scope: invalid.illegal.cmakecache
+
+  expect-value:
+    - match: '='
+      scope: keyword.operator.assignment.cmakecache
+    - match: $
+      pop: true
+    - match: .*
+      scope: string.unqouted.cmakecache
+      pop: true

--- a/CMakeCache.tmPreferences
+++ b/CMakeCache.tmPreferences
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Symbol List</string>
+   <key>scope</key>
+   <string>variable.parameter.cmakecache</string>
+   <key>settings</key>
+   <dict>
+      <key>showInSymbolList</key>
+      <integer>1</integer>
+
+      <!-- No need to show local variables in the global symbol list -->
+      <key>showInIndexedSymbolList</key>
+      <integer>0</integer>
+   </dict>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# Sublime Text 2/3 - CMake Package #
+# CMake
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/zyxar/Sublime-CMakeLists?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 * Simple auto-indentation support.
-* Syntax highlighting, based on [CMake 3.0][1].
+* Syntax highlighting for CMakeLists.txt files and `*.cmake` files, based on 
+  [CMake 3.0][1].
+* Syntax highlighting for CMakeCache.txt files.
+* Syntax highlighting for `.h.in` and `.hpp.in` files.
 * Basic snippets.
 * Basic keybindings.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CMake
+# Sublime Text 2/3 - CMake Package #
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/zyxar/Sublime-CMakeLists?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
I have this syntax in my CMakeBuilder plugin, but I think it's better if this plugin has it. It provides highlighting for CMakeCache.txt files.