### PR TITLE
Remove DOCTYPE from comments meta file

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>name</key>


### PR DESCRIPTION
Sorry for the delay again.

You  can [safely remove](https://github.com/sublimehq/Packages/commit/61bfd68ea07a3aede68cd6a65c80be702b3d6db8) the DOCTYPE from the tmPreferences files.