### PR TITLE
Remove DOCTYPE and uuid from indent meta file

### DIFF
--- a/Indent.tmPreferences
+++ b/Indent.tmPreferences
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>name</key>
@@ -13,7 +12,5 @@
 		<key>increaseIndentPattern</key>
 		<string>^\s*(?i:else|elseif|if|function|foreach|while|macro)\s*\([^)]*\)\s*$</string>
 	</dict>
-	<key>uuid</key>
-	<string>cd45e923-9fe3-4d1c-8482-90e651d5bcdb</string>
 </dict>
 </plist>


### PR DESCRIPTION
Same reason as https://github.com/zyxar/Sublime-CMakeLists/pull/19