### PR TITLE
Improvements to the cmake syntax

### DIFF
--- a/CMake.sublime-syntax
+++ b/CMake.sublime-syntax
@@ -1,167 +1,663 @@
 %YAML 1.2
----
+# https://www.sublimetext.com/docs/3/syntax.html
+# https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html
+--- #---------------------------------------------------------------------------
 name: CMake
 comment: Written by Raoul Wols <raoulwols@gmail.com>, 2017
 file_extensions: [CMakeLists.txt, cmake]
 scope: source.cmake
-
+#-------------------------------------------------------------------------------
 variables:
-  # https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#unquoted-argument
   # Note: we're not doing legacy
-  unquoted_element: "[^ \t()#\"\\']"
-  unquoted_argument: "{{unquoted_element}}+"
-
-  spaces: '[ \t]*'
-  identifier: \b[A-Za-z_][A-Za-z0-9_]*\b
-  IDENTIFIER: \b@?[A-Z_][A-Z0-9_]*(?=[^\w-<>=\$])
-  variable_start: \$(?:ENV)?\{
-  variable_end: \}
-
+  unquoted_argument_element: "[^ \t()#\"\\']"
+  unquoted_argument: "{{unquoted_argument_element}}+"
+  identifier: \b[[:alpha:]_][[:alnum:]_]*\b
+  generic_named_parameter: \b@?[A-Z_][A-Z0-9_]*(?=[^\w-<>=\$])
+#-------------------------------------------------------------------------------
 contexts:
+  prototype:
+    - include: comment-block
+    - include: comment-line
+    - include: variable-substitution
+    - include: generator-expression
+
   main:
-    - include: comment
-    - include: command
+    - include: if
+    - include: foreach
+    - include: while
+    - include: set
+    - include: function
+    - include: macro
+    - include: include
+    - include: illegal-command
+    - include: generic-command
 
-  command:
+  illegal-command:
+    - match: (?i)\bendif\b
+      scope: invalid.illegal.stray.endif.cmake
+    - match: (?i)\belse\b
+      scope: invalid.illegal.stray.else.cmake
+    - match: (?i)\belseif\b
+      scope: invalid.illegal.stray.elseif.cmake
+    - match: (?i)\bendforeach\b
+      scope: invalid.illegal.stray.endforeach.cmake
+    - match: (?i)\bendwhile\b
+      scope: invalid.illegal.stray.endwhile.cmake
+    - match: (?i)\bbreak\b
+      scope: invalid.illegal.stray.break.cmake
+    - match: (?i)\bendfunction\b
+      scope: invalid.illegal.stray.endfunction.cmake
+    - match: (?i)\bendmacro\b
+      scope: invalid.illegal.stray.endmacro.cmake
 
-    # If we encounter a keyword, assign keyword.control to it.
-    - match: ((?:end)?if|elif|else|(?:end)?foreach|(?:end)?while){{spaces}}
-      captures:
-        0: meta.function-call.cmake
-        1: keyword.control.cmake
+  args-illegal-boilerplate:
+    - match: \s+
+    - match: \n
+    - match: .+
+      scope: invalid.illegal.expected-opening-brace.cmake
+      pop: true
 
-    # If we encounter a set(...) command, go into set-special-handling.
-    - match: (set){{spaces}}(?=\()
-      captures:
-        0: meta.function-call.cmake
-        1: variable.function.cmake
-      push: set-special-handling
+  # --- INCLUDE ----------------------------------------------------------------
 
-    # If we encounter any other identifier, assume it's a function/command
-    - match: '({{identifier}}){{spaces}}'
-      captures:
-        0: meta.function-call.cmake
-        1: variable.function.cmake
+  include:
+    - match: (?i)\binclude\b
+      scope: keyword.control.import.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: include-args
+        - include: args-illegal-boilerplate
 
-    # If we encounter an opening parenthesis, start handling the arguments
+  include-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bOPTIONAL\b
+      scope: variable.parameter.include.OPTIONAL.cmake
+    - match: \bNO_POLICY_SCOPE\b
+      scope: variable.parameter.include.NO_POLICY_SCOPE.cmake
+    - match: \bRESULT_VARIABLE\b
+      scope: variable.parameter.include.RESULT_VARIABLE.cmake
+      push:
+        - match: \b{{identifier}}\b
+          scope: variable.other.readwrite.cmake
+          pop: true
+        - match: \s+
+        - match: \n
+        - match: ''
+          pop: true
+    - include: args-common
+
+  # --- FUNCTION / ENDFUNCTION -------------------------------------------------
+
+  function:
+    - match: (?i)\bfunction\b
+      scope: support.function.function.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [function-body, function-args-first]
+        - include: args-illegal-boilerplate
+
+  function-args-first:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: '{{identifier}}'
+      scope: entity.name.function.cmake
+      set: function-args-rest
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      set: function-args-rest
+
+  function-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+    - match: '{{identifier}}'
+      scope: variable.parameter.cmake
+
+  function-body:
+    - meta_scope: meta.group.function.cmake
+    - include: endfunction
+    - include: main
+
+  endfunction:
+    - match: (?i)\bendfunction\b
+      scope: support.function.endfunction.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+        - include: args-illegal-boilerplate
+
+  # --- MACRO / ENDMACRO -------------------------------------------------------
+
+  macro:
+    - match: (?i)\bmacro\b
+      scope: support.function.macro.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [macro-body, macro-args-first]
+        - include: args-illegal-boilerplate
+
+  macro-args-first:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: '{{identifier}}'
+      scope: entity.name.function.cmake
+      set: macro-args-rest
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      set: macro-args-rest
+
+  macro-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+    - match: '{{identifier}}'
+      scope: variable.parameter.cmake
+
+  macro-body:
+    - meta_scope: meta.group.function.cmake
+    - include: endmacro
+    - include: main
+
+  endmacro:
+    - match: (?i)\bendmacro\b
+      scope: support.function.endmacro.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+        - include: args-illegal-boilerplate
+
+  # --- IF / ELSEIF / ELSE / ENDIF ---------------------------------------------
+
+  if:
+    - match: (?i)\bif\b
+      scope: keyword.control.if.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [if-body, if-args]
+        - include: args-illegal-boilerplate
+
+  if-body:
+    - meta_scope: meta.group.if.cmake
+    - include: else
+    - include: elseif
+    - include: endif
+    - include: break
+    - include: main
+
+  if-args:
+    - meta_scope: meta.function-call.arguments.cmake
     - match: \(
       scope: punctuation.section.parens.begin.cmake
-      push: command-arguments
+      push: if-args
+    - match: \bSTREQUAL\b
+      scope: variable.parameter.if.STREQUAL.cmake
+    - match: \bNOT\b
+      scope: keyword.operator.logical.NOT.cmake
+    - match: \bAND\b
+      scope: keyword.operator.logical.AND.cmake
+    - match: \bOR\b
+      scope: keyword.operator.logical.OR.cmake
+    - match: \bCOMMAND\b
+      scope: variable.parameter.if.COMMAND.cmake
+    - match: \bPOLICY\b
+      scope: variable.parameter.if.POLICY.cmake
+    - match: \bTARGET\b
+      scope: variable.parameter.if.TARGET.cmake
+    - match: \bTEST\b
+      scope: variable.parameter.if.TEST.cmake
+    - match: \bEXISTS\b
+      scope: variable.parameter.if.EXISTS.cmake
+    - match: \bIS_NEWER_THAN\b
+      scope: variable.parameter.if.IS_NEWER_THAN.cmake
+    - match: \bIS_DIRECTORY\b
+      scope: variable.parameter.if.IS_DIRECTORY.cmake
+    - match: \bIS_SYMLINK\b
+      scope: variable.parameter.if.IS_SYMLINK.cmake
+    - match: \bIS_ABSOLUTE\b
+      scope: variable.parameter.if.IS_ABSOLUTE.cmake
+    - match: \b(VERSION_|STR)?LESS\b
+      scope: variable.parameter.if.LESS.cmake
+    - match: \b(VERSION_|STR)?GREATER\b
+      scope: variable.parameter.if.GREATER.cmake
+    - match: \b(VERSION_|STR)?EQUAL\b
+      scope: variable.parameter.if.EQUAL.cmake
+    - match: \b(VERSION_|STR)?LESS_EQUAL\b
+      scope: variable.parameter.if.LESS_EQUAL.cmake
+    - match: \b(VERSION_|STR)?GREATER_EQUAL\b
+      scope: variable.parameter.if.GREATER_EQUAL.cmake
+    - match: \bMATCHES\b
+      scope: variable.parameter.if.MATCHES.cmake
+      push:
+        - match: \[(=*)\[
+          captures:
+            1: punctuation.definition.string.begin.cmake
+          push:
+            - meta_include_prototype: false
+            - meta_scope: string.regexp.cmake
+            - match: \]\1\]
+              scope: punctuation.definition.string.end.cmake
+              pop: true
+            - include: scope:source.regexp#base
+        - match: \s+
+        - match: \n
+        - match: ''
+          pop: true
+    - include: args-common
 
-  set-special-handling:
-    - match: (\(){{spaces}}({{unquoted_argument}})
-      captures:
-        1: punctuation.section.parens.begin.cmake
-        2: variable.other.cmake
-      set: command-arguments
+  elseif:
+    - match: (?i)\belseif\b
+      scope: keyword.control.elseif.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [elseif-body, if-args]
+        - include: args-illegal-boilerplate
 
-  command-arguments:
+  elseif-body:
+    - meta_scope: meta.group.elseif.cmake
+    - include: elseif
+    - include: else
+    - include: endif
+    - include: break
+    - include: main
+
+  else:
+    - match: (?i)\b\belse\b
+      scope: keyword.control.else.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [else-body, if-args]
+        - include: args-illegal-boilerplate
+
+  else-body:
+    - meta_scope: meta.group.else.cmake
+    - include: endif
+    - include: break
+    - include: main
+    - match: (?i)\belse\b
+      scope: invalid.illegal.stray.else.cmake
+    - match: (?i)\belseif\b
+      scope: invalid.illegal.stray.elseif.cmake
+
+  endif:
+    - match: (?i)\bendif\b
+      scope: keyword.control.endif.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: if-args
+        - include: args-illegal-boilerplate
+
+  # --- FOREACH / ENDFOREACH ---------------------------------------------------
+
+  foreach:
+    - match: (?i)\bforeach\b
+      scope: keyword.control.foreach.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [foreach-body, foreach-args]
+        - include: args-illegal-boilerplate
+
+  foreach-args:
     - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+    - match: \bIN\b
+      scope: variable.parameter.foreach.IN.cmake
+    - match: \bLISTS\b
+      scope: variable.parameter.foreach.LISTS.cmake
+    - match: \bITEMS\b
+      scope: variable.parameter.foreach.ITEMS.cmake
+    - match: \bRANGE\b
+      scope: variable.parameter.foreach.RANGE.cmake
+
+  foreach-body:
+    - meta_scope: meta.group.foreach.cmake
+    - include: break
+    - include: continue
+    - include: endforeach
+    - include: main
+
+  endforeach:
+    - match: (?i)\bendforeach\b
+      scope: keyword.control.endforeach.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: foreach-args
+        - include: args-illegal-boilerplate
+
+  # --- WHILE / ENDWHILE -------------------------------------------------------
+
+  while:
+    - match: (?i)\bwhile\b
+      scope: keyword.control.while.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [while-body, if-args]
+        - include: args-illegal-boilerplate
+
+  while-body:
+    - meta_scope: meta.group.while.cmake
+    - include: break
+    - include: continue
+    - include: endwhile
+    - include: main
+
+  endwhile:
+    - match: (?i)\bendwhile\b
+      scope: keyword.control.endwhile.cmake
+      set:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: if-args
+        - include: args-illegal-boilerplate
+
+  # --- BREAK ------------------------------------------------------------------
+
+  break:
+    - match: (?i)\bbreak\b
+      scope: keyword.control.break.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: break-args
+        - include: args-illegal-boilerplate
+
+  break-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+
+  #--- CONTINUE ----------------------------------------------------------------
+  
+  continue:
+    - match: (?i)\bcontinue\b
+      scope: keyword.control.continue.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: continue-args
+        - include: args-illegal-boilerplate
+
+  continue-args:
+    - meta_scope: meta.function-call.arguments.cmake
+    - include: args-common
+
+  #--- SET ---------------------------------------------------------------------
+
+  set:
+    - match: (?i)\bset\b
+      scope: support.function.set.cmake
+      push:
+        - meta_scope: meta.function-call.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: [set-args-rest, set-args-first]
+
+  set-args-first:
+    - match: '{{identifier}}'
+      scope: variable.other.readwrite.assignment.cmake
+      pop: true
+    - include: variable-substitution
+    - match: \s+
+    - match: ''
+      pop: true
+
+  set-args-rest:
+    - meta_scope: meta.function-call.arguments.cmake
+    - match: \bFORCE\b
+      scope: variable.parameter.foreach.FORCE.cmake
+    - match: \bPARENT_SCOPE\b
+      scope: variable.parameter.foreach.PARENT_SCOPE.cmake
+    - match: \bCACHE\b
+      scope: variable.parameter.foreach.CACHE.cmake
+      push:
+        - match: \s*(FILEPATH)
+          captures:
+            1: storage.type.FILEPATH.cmake
+          pop: true
+        - match: \s*(PATH)
+          captures:
+            1: storage.type.PATH.cmake
+          pop: true
+        - match: \s*(STRING)
+          captures:
+            1: storage.type.STRING.cmake
+          pop: true
+        - match: \s*(BOOL)
+          captures:
+            1: storage.type.BOOL.cmake
+          pop: true
+        - match: \s*(INTERNAL)
+          captures:
+            1: storage.type.INTERNAL.cmake
+          pop: true
+        # anything else we scope as an error
+        - match: \s*([^\s]*)
+          captures:
+            1: invalid.illegal.expected-type.cmake
+          pop: true
+    - include: args-common
+
+  #--- COMMON FUNCTIONALITY FOR COMMANDS ---------------------------------------
+
+  args-common:
     - match: \)
       scope: punctuation.section.parens.end.cmake
       pop: true
     - match: \(
-      scope: punctuation.section.parens.begin.cmake
-      push: command-arguments
-    - include: bracket-argument
-    - match: '"'
-      scope: punctuation.definition.string.begin.cmake
-      push: quoted-argument
-    - match: (?={{IDENTIFIER}})
+      scope: invalid.illegal.stray.parenthesis.cmake
+    - include: string
+
+  generic-command:
+    - match: \b{{identifier}}\b
+      scope: variable.function.generic.cmake
+      push:
+        - meta_scope: meta.function-call.generic.cmake
+        - match: (?=\()
+          set:
+            - match: \(
+              scope: punctuation.section.parens.begin.cmake
+              set: generic-args
+
+  generic-args:
+    - meta_scope: meta.function-call.arguments.generic.cmake
+    - match: \)
+      scope: punctuation.section.parens.end.cmake
+      pop: true
+    - match: (?={{generic_named_parameter}})
       push: unquoted-argument-or-keyword
-    - match: (?={{unquoted_argument}})
-      push: unquoted-argument
-    - include: comment
+    - include: string-unquoted
+    - include: string-quoted-double
+    - include: string-quoted-single
 
   # https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#unquoted-argument
   unquoted-argument-or-keyword:
-    - meta_scope: variable.parameter.cmake
+    - meta_scope: variable.parameter.generic.cmake
     - match: (?=\t| |\(|\)|\#|\"|\\)
       pop: true
-    - include: variable 
 
-  quoted-argument:
-    - meta_scope: string.quoted.double.cmake
-    # https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#escape-sequences
+  #--- STRING HANDLING ---------------------------------------------------------
+
+  string:
+    - include: string-raw
+    - include: string-quoted-double
+    - include: string-quoted-single
+    - include: string-unquoted
+
+  string-raw:
+    - match: \[(=*)\[
+      scope: punctuation.definition.string.begin.cmake
+      push: 
+        - meta_include_prototype: false
+        - meta_scope: string.raw.cmake
+        - match: \]\1\]
+          scope: punctuation.definition.string.end.cmake
+          pop: true
+
+  string-quoted-double:
+    - match: '"'
+      scope: punctuation.definition.string.begin.cmake
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.cmake
+        - match: '"'
+          scope: punctuation.definition.string.end.cmake
+          pop: true
+        - include: escape-sequences
+        - include: highlight-semicolon
+        - include: variable-substitution
+        - include: generator-expression
+
+  string-quoted-single:
+    - match: "'"
+      scope: punctuation.definition.string.begin.cmake
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.single.cmake
+        - match: "'"
+          scope: punctuation.definition.string.end.cmake
+          pop: true
+        - include: escape-sequences
+        - include: highlight-semicolon
+        - include: variable-substitution
+        - include: generator-expression
+
+  string-unquoted:
+    - match: (?={{unquoted_argument}})
+      push:
+        - meta_include_prototype: false
+        - meta_scope: meta.string.unquoted.cmake
+        - include: variable-substitution
+        - include: generator-expression
+        - match: \\[; ()#"\\]
+          scope: constant.character.escape.cmake
+        - match: \\.
+          scope: invalid.illegal.character.escape.cmake
+        - match: (?=\t| |\(|\)|\#|\"|\\|\n)
+          pop: true  
+        - match: (?=\s*$)
+          set:
+            - match: \s*$
+              pop: true
+        - match: (?=\s*#)
+          set: prototype
+        - include: highlight-semicolon
+
+  highlight-semicolon:
+    - match: ;
+      scope: punctuation.separator.cmake
+
+  escape-sequences:
     - match: \\[()#" \\$@^trn;]
       scope: constant.character.escape.cmake
     - match: \\.
       scope: invalid.illegal.character.escape.cmake
-    - match: '"'
-      scope: punctuation.definition.string.end.cmake
-      pop: true
-    - match: ;
-      scope: punctuation.separator.cmake
-    - include: variable
-    - include: generator-expression
 
-  # https://cmake.org/cmake/help/v3.0/manual/cmake-language.7.html#unquoted-argument
-  unquoted-argument:
-    - meta_scope: string.unquoted.cmake
-    - match: \\[; ()#"\\]
-      scope: constant.character.escape.cmake
-    - match: \\.
-      scope: invalid.illegal.character.escape.cmake
-    - match: (?=\t| |\(|\)|\#|\"|\\)
-      pop: true
-    - match: ;
-      scope: punctuation.separator.cmake
-    - include: variable
-    - include: generator-expression
+  #--- VARIABLES AND GENERATOR EXPRESSIONS -------------------------------------
 
-  bracket-argument:
-    - match: (\[(={0,16})\[)
-      scope: punctuation.definition.string.begin.cmake
-      push:
-        - meta_scope: string.quoted.double.cmake
-        - match: \]\2\]
-          scope: punctuation.definition.string.end.cmake
-          pop: true
-
-  variable:
-    - match: '{{variable_start}}'
-      scope: keyword.other.block.start.cmake
+  variable-substitution:
+    - match: \$(?:ENV)?\{
+      scope: keyword.other.block.begin.cmake
       push:
         - meta_scope: meta.text-substitution.cmake
-        - match: '{{variable_end}}'
+        - match: \}
           scope: keyword.other.block.end.cmake
           pop: true
         - match: '{{identifier}}'
-          scope: variable.cmake
-        - include: variable
+          scope: variable.other.readwrite.cmake
+        - include: prototype
 
   generator-expression:
     - match: \$<
-      scope: keyword.other.block.start.cmake
+      scope: keyword.other.block.begin.cmake
       push:
-        - meta_scope: meta.text-substitution.cmake
-        - match: '>'
-          scope: keyword.other.block.end.cmake
-          pop: true
-        - match: '{{identifier}}'
-          scope: variable.cmake
+        - meta_scope: meta.generator-expression.cmake
+        - include: generator-expression-common
         - match: ':'
-          scope: punctuation.definition.generator-expression.separator.cmake
-        - include: generator-expression
-        - include: variable
+          scope: punctuation.separator.generator-expression.cmake
+          set:
+            - meta_content_scope: meta.generator-expression.cmake
+            - match: ':'
+              scope: invalid.illegal.too-many-colons.cmake
+            - include: generator-expression-common
+            - include: prototype
+        - include: prototype
 
-  comment:
-    - include: bracket-comment
-    - include: line-comment
+  generator-expression-common:
+    - match: '>'
+      scope: keyword.other.block.end.cmake
+      pop: true
+    - match: '{{identifier}}'
+      scope: variable.other.readwrite.cmake
 
-  bracket-comment:
-    - match: \#(\[(={0,16})\[)
+  #--- COMMENT HANDLING --------------------------------------------------------
+
+  comment-block:
+    - match: \#\[(=*)\[
       scope: punctuation.definition.comment.begin.cmake
       push:
         - meta_scope: comment.block.cmake
-        - match: \]\2\]
+        - match: \]\1\]
           scope: punctuation.definition.comment.end.cmake
           pop: true
 
-  line-comment:
+  comment-line:
     - match: \#
-      scope: punctuation.definition.comment.begin.cmake
+      scope: punctuation.definition.comment.cmake
       push:
         - meta_scope: comment.line.cmake
-        - match: \n
+        - match: $
           pop: true

--- a/CMake.sublime-syntax
+++ b/CMake.sublime-syntax
@@ -609,20 +609,25 @@ contexts:
   #--- VARIABLES AND GENERATOR EXPRESSIONS -------------------------------------
 
   variable-substitution:
-    - match: \$(?:ENV)?\{
-      scope: keyword.other.block.begin.cmake
+    - match: (\$)(ENV)?(\{)
+      captures:
+        1: punctuation.definition.variable.substitution.cmake
+        2: keyword.operator.word.cmake
+        3: punctuation.section.braces.begin.cmake
       push:
         - meta_scope: meta.text-substitution.cmake
         - match: \}
-          scope: keyword.other.block.end.cmake
+          scope: punctuation.section.braces.end.cmake
           pop: true
         - match: '{{identifier}}'
           scope: variable.other.readwrite.cmake
         - include: prototype
 
   generator-expression:
-    - match: \$<
-      scope: keyword.other.block.begin.cmake
+    - match: (\$)(<)
+      captures:
+        1: punctuation.definition.variable.generator-expression.cmake
+        2: punctuation.section.block.begin.cmake
       push:
         - meta_scope: meta.generator-expression.cmake
         - include: generator-expression-common
@@ -638,7 +643,7 @@ contexts:
 
   generator-expression-common:
     - match: '>'
-      scope: keyword.other.block.end.cmake
+      scope: punctuation.section.block.end.cmake
       pop: true
     - match: '{{identifier}}'
       scope: variable.other.readwrite.cmake

--- a/syntax_test.txt
+++ b/syntax_test.txt
@@ -1,8 +1,8 @@
 # SYNTAX TEST "Packages/Sublime-CMakeLists/CMake.sublime-syntax"
 
 # This is a comment
-# ^^^^^^^^^^^^^^^^^^ comment.line
-#      ^^^^^^^^^^^^^ comment.line
+# ^^^^^^^^^^^^^^^^^ comment.line
+#      ^^^^^^^^^^^^ comment.line
 
 # <- source.cmake
 
@@ -11,48 +11,47 @@
 #         ^ comment.line
 
 if (NOT (${something} AND ${something_else}))
-#  ^ punctuation.section.parens.begin.cmake
-#       ^ punctuation.section.parens.begin.cmake
-#                                          ^ punctuation.section.parens.end.cmake
-#                                           ^ punctuation.section.parens.end.cmake
+#  ^ punctuation.section.parens.begin
+#       ^ punctuation.section.parens.begin
+#                                          ^ punctuation.section.parens.end
+#                                           ^ punctuation.section.parens.end
 
 endif()
 
 set(x "\! \@ \# \$ \% \& \* \( \) \a \b \c \d \e \f \g \h \i \j \k \l \m \n \o \p \q \r \s \t \u \v \w \x \y \z")
-#      ^^ invalid.illegal.character.escape.cmake
-#         ^^ constant.character.escape.cmake
-#            ^^ constant.character.escape.cmake
-#               ^^ constant.character.escape.cmake
-#                  ^^ invalid.illegal.character.escape.cmake
-#                        ^^ invalid.illegal.character.escape.cmake
-#                           ^^ constant.character.escape.cmake
-#                              ^^ constant.character.escape.cmake
-#                                 ^^ invalid.illegal.character.escape.cmake
-#                                    ^^ invalid.illegal.character.escape.cmake
-#                                       ^^ invalid.illegal.character.escape.cmake
-#                                          ^^ invalid.illegal.character.escape.cmake
-#                                             ^^ invalid.illegal.character.escape.cmake
-#                                                ^^ invalid.illegal.character.escape.cmake
-#                                                                        ^^ constant.character.escape.cmake
+#      ^^ invalid.illegal.character.escape
+#         ^^ constant.character.escape
+#            ^^ constant.character.escape
+#               ^^ constant.character.escape
+#                  ^^ invalid.illegal.character.escape
+#                        ^^ invalid.illegal.character.escape
+#                           ^^ constant.character.escape
+#                              ^^ constant.character.escape
+#                                 ^^ invalid.illegal.character.escape
+#                                    ^^ invalid.illegal.character.escape
+#                                       ^^ invalid.illegal.character.escape
+#                                          ^^ invalid.illegal.character.escape
+#                                             ^^ invalid.illegal.character.escape
+#                                                ^^ invalid.illegal.character.escape
+#                                                                        ^^ constant.character.escape
 
 cmake_minimum_required(VERSION 3.0)
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#                     ^ punctuation.section.parens.begin.cmake
-#                                 ^ punctuation.section.parens.end.cmake
-#                      ^^^^^^^^^^^ meta.function-call.arguments.cmake
-#         ^ variable.function.cmake
+#                     ^ punctuation.section.parens.begin
+#                                 ^ punctuation.section.parens.end
+#                      ^^^^^^^^^^^ meta.function-call.arguments
+#         ^ variable.function
 
 set(some_var "Hello, world!")
-# ^ variable.function.cmake
-#   ^ variable.other.cmake
-#            ^ string.quoted.double.cmake
-#  ^ punctuation.section.parens.begin.cmake
-#                           ^ punctuation.section.parens.end.cmake
+# ^ support.function
+#   ^ variable.other
+#            ^ string.quoted.double
+#  ^ punctuation.section.parens.begin
+#                           ^ punctuation.section.parens.end
 
 set(var_with_quotes "This is a string with \"embedded\" quotes.")
 
 set(another ${some_var})
-#                      ^ punctuation.section.parens.end.cmake
+#                      ^ punctuation.section.parens.end
 
 set(blarg
     # A comment inbetween
@@ -60,14 +59,14 @@ set(blarg
     foobar)
 
 message(STATUS "The some_var variable has the value \"${some_var}\"")
-#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.cmake
-#       ^^^^^^ variable.parameter.cmake 
-#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.cmake
-#                                                   ^^ constant.character.escape.cmake
-#                                                     ^^ keyword.other.block.start.cmake
-#                                                       ^^^^^^^^ meta.text-substitution.cmake
-#                                                               ^ keyword.other.block.end.cmake
-#                                                                ^^ constant.character.escape.cmake
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
+#       ^^^^^^ variable.parameter 
+#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#                                                   ^^ constant.character.escape
+#                                                     ^^ keyword.other.block.begin
+#                                                       ^^^^^^^^ meta.text-substitution
+#                                                               ^ keyword.other.block.end
+#                                                                ^^ constant.character.escape
 
 target_link_libraries(mytarget PUBLIC
         ${Boost_LIBRARIES}
@@ -76,34 +75,34 @@ target_link_libraries(mytarget PUBLIC
         )
 
 set(asdf nested_vars_test some${var_inside_${anot${h}er_var}_and_moving_on}_even_further)
-#  ^ punctuation.section.parens.begin.cmake
-#                             ^^ keyword.other.block.start.cmake
-#                                          ^^ keyword.other.block.start.cmake
-#                                                          ^ keyword.other.block.end.cmake
-#                                                                         ^ keyword.other.block.end.cmake
+#  ^ punctuation.section.parens.begin
+#                             ^^ keyword.other.block.begin
+#                                          ^^ keyword.other.block.begin
+#                                                          ^ keyword.other.block.end
+#                                                                         ^ keyword.other.block.end
 
 set(some_list "one;two;thre\;e")
-#                 ^ punctuation.separator.cmake
-#                     ^ punctuation.separator.cmake
-#                          ^^ constant.character.escape.cmake
+#                 ^ punctuation.separator
+#                     ^ punctuation.separator
+#                          ^^ constant.character.escape
 
 if("${somevar}" STREQUAL "something else")
-#^ keyword.control.cmake
+#^ keyword.control
 
-elif("${somevar}" STREQUAL whatever AND NOT ${another_var} VERSION_LESS 1.2.3)
-#^^^ keyword.control.cmake
+elseif("${somevar}" STREQUAL whatever AND NOT ${another_var} VERSION_LESS 1.2.3)
+#^^^^^ keyword.control
 
-elif  (STREQUALasdf sTREQUAL COMMAND ANDNOT AND NOT VERSION_GREATER TARGET)
-#^^^ keyword.control.cmake
-#      ^^^^^^^^^^^^ string.unquoted.cmake 
-#                   ^^^^^^^^ string.unquoted.cmake 
-#                            ^^^^^^^ variable.parameter.cmake
-#                                    ^^^^^^ variable.parameter.cmake
-#                                           ^^^ variable.parameter.cmake
-#                                               ^^^ variable.parameter.cmake
+elseif  (STREQUALasdf sTREQUAL COMMAND ANDNOT AND NOT VERSION_GREATER TARGET)
+#^^^^^ keyword.control
+#        ^^^^^^^^^^^^ meta.string.unquoted 
+#                     ^^^^^^^^ meta.string.unquoted 
+#                              ^^^^^^^ variable.parameter
+#                                      ^^^^^^ - variable.parameter
+#                                             ^^^ keyword.operator
+#                                                 ^^^ keyword.operator
 
 endif   ()
-#^^^^ keyword.control.cmake
+#^^^^ keyword.control
 
 target_include_directories(mytarget PUBLIC $sdf>)
 
@@ -119,23 +118,23 @@ if (NOT "${the_var}" MATCHES "[A-Za-z]\\d+")
 # maybe add regex as an embedded syntax here
 
 if ($ENV{LD_LIBRARY_PATH} STREQUAL /usr/local/lib)
-#   ^^^^^ keyword.other.block.start.cmake
-#                                  ^^^^^^^^^^^^^^ string.unquoted.cmake
+#   ^^^^^ keyword.other.block.begin
+#                                  ^^^^^^^^^^^^^^ meta.string.unquoted
 endif()
 
 include(AddFileDependencies)
 include(CMakeParseArguments)
 
   install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/LLVMConfig.cmake
-    ${llvm_cmake_builddir}/LLVMConfigVersion.cmake
-    LLVM-Config.cmake
-#   ^ string.unquoted.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/LLVMConfig
+    ${llvm_cmake_builddir}/LLVMConfigVersion
+    LLVM-Config
+#   ^ meta.string.unquoted
     DESTINATION ${LLVM_INSTALL_PACKAGE_DIR}
-#   ^ variable.parameter.cmake
+#   ^ variable.parameter
     COMPONENT cmake-exports)
-#   ^ variable.parameter.cmake
-#             ^ string.unquoted.cmake
+#   ^ variable.parameter
+#             ^ meta.string.unquoted
 
 function(llvm_replace_compiler_option var old new)
   # Replaces a compiler option or switch `old' in `var' by `new'.
@@ -155,53 +154,53 @@ function(llvm_replace_compiler_option var old new)
   set( ${var} "${${var}}" PARENT_SCOPE )
 endfunction(llvm_replace_compiler_option)
 
-# Generate LLVMConfig.cmake for the install tree.
+# Generate LLVMConfig for the install tree.
 set(LLVM_CONFIG_CODE "
-# Compute the installation prefix from this LLVMConfig.cmake file location.
+# Compute the installation prefix from this LLVMConfig file location.
 get_filename_component(LLVM_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)")
 # Construct the proper number of get_filename_component(... PATH)
 # calls to compute the installation prefix.
 string(REGEX REPLACE "/" ";" _count "${LLVM_INSTALL_PACKAGE_DIR}")
 foreach(p ${_count})
-#^^^^^^ keyword.control.cmake
+#^^^^^^ keyword.control
   set(LLVM_CONFIG_CODE "${LLVM_CONFIG_CODE}
 get_filename_component(LLVM_INSTALL_PREFIX \"\${LLVM_INSTALL_PREFIX}\" PATH)")
 endforeach(p)
-#^^^^^^^^^ keyword.control.cmake
+#^^^^^^^^^ keyword.control
 set(LLVM_CONFIG_INCLUDE_DIRS "\${LLVM_INSTALL_PREFIX}/include")
 set(LLVM_CONFIG_LIBRARY_DIRS "\${LLVM_INSTALL_PREFIX}/lib\${LLVM_LIBDIR_SUFFIX}")
 set(LLVM_CONFIG_CMAKE_DIR "\${LLVM_INSTALL_PREFIX}/${LLVM_INSTALL_PACKAGE_DIR}")
-#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.cmake
+#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 #                          ^^ constant.character.escape
-#                                                  ^^ keyword.other.block.start
+#                                                  ^^ keyword.other.block.begin
 #                                                                            ^ keyword.other.block.end
 set(LLVM_CONFIG_BINARY_DIR "\${LLVM_INSTALL_PREFIX}")
 set(LLVM_CONFIG_TOOLS_BINARY_DIR "\${LLVM_INSTALL_PREFIX}/bin")
-set(LLVM_CONFIG_EXPORTS_FILE "\${LLVM_CMAKE_DIR}/LLVMExports.cmake")
+set(LLVM_CONFIG_EXPORTS_FILE "\${LLVM_CMAKE_DIR}/LLVMExports")
 set(LLVM_CONFIG_EXPORTS "${LLVM_EXPORTS}")
 configure_file(
-  LLVMConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/LLVMConfig.cmake
+  LLVMConfig.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/LLVMConfig
   @ONLY)
-# ^^^^^ string.unquoted.cmake
+# ^^^^^ meta.string.unquoted
 
 target_include_directories(module PUBLIC $<CMAKE_COMPILER_ID>)
-# ^^^^^^^^^^^^^^^^^^^^^^^^ variable.function.cmake
+# ^^^^^^^^^^^^^^^^^^^^^^^^ variable.function
 #                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-#                         ^ punctuation.section.parens.begin.cmake
-#                          ^^^^^^ string.unquoted.cmake
-#                                 ^^^^^^ variable.parameter.cmake
-#                                        ^^ keyword.other.block.start.cmake
-#                                          ^^^^^^^^^^^^^^^^^ meta.text-substitution.cmake
-#                                                           ^ keyword.other.block.end.cmake
-#                                                            ^ punctuation.section.parens.end.cmake
+#                         ^ punctuation.section.parens.begin
+#                          ^^^^^^ meta.string.unquoted
+#                                 ^^^^^^ variable.parameter
+#                                        ^^ keyword.other.block.begin
+#                                          ^^^^^^^^^^^^^^^^^ meta.generator-expression
+#                                                           ^ keyword.other.block.end
+#                                                            ^ punctuation.section.parens.end
 
 
 while(${var})
-#^^^^ keyword.control.cmake
+#^^^^ keyword.control
   myfunc(mytarget NAMED_ARG some_value)
 endwhile(${var})
-#^^^^^^^ keyword.control.cmake
+#^^^^^^^ keyword.control
 
 set(TGT_PATH $<TARGET_FILE:tgt1>)
 
@@ -209,11 +208,11 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
   # Build an interface library target:
   add_library(module INTERFACE)
   target_include_directories(module INTERFACE $<BUILD_INTERFACE:${PYBIND11_INCLUDE_DIR}>
-#                                               ^^^^^^^^^^^^^^^ variable.cmake
-#                                                              ^ punctuation.definition.generator-expression.separator.cmake
-#                                                               ^^ keyword.other.block.start.cmake
-#                                                                 ^^^^^^^^^^^^^^^^^^^^ variable.cmake
-#                                                                                     ^^ keyword.other.block.end.cmake
+#                                               ^^^^^^^^^^^^^^^ variable
+#                                                              ^ punctuation.separator
+#                                                               ^^ keyword.other.block.begin
+#                                                                 ^^^^^^^^^^^^^^^^^^^^ variable
+#                                                                                     ^^ keyword.other.block.end
                                               $<BUILD_INTERFACE:${PYTHON_INCLUDE_DIRS}>
                                               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
   if(WIN32 OR CYGWIN)
@@ -225,9 +224,9 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
 
   add_library(pybind11::module #[[new style bracket comments!]] ALIAS module)
 #                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block
-#                                                               ^^^^^ variable.parameter.cmake
-#                                                                     ^^^^^^ string.unquoted.cmake
-#                                                                           ^ punctuation.section.parens.end.cmake
+#                                                               ^^^^^ variable.parameter
+#                                                                     ^^^^^^ meta.string.unquoted
+#                                                                           ^ punctuation.section.parens.end
                                               
 endif()
 
@@ -242,7 +241,7 @@ endif()
                         particular
 
 ]=] # and this is where a regular line comment starts 
-# ^ comment.block.cmake
+# ^ comment.block
 #   ^ comment.line
 
 add_executable(hel#lo main.cpp)
@@ -255,14 +254,14 @@ add_executable(hel#lo main.cpp)
 foreach(arg
     NoSpace
     Escaped\ Space
-#   ^^^^^^^^^^^^^^ string.unquoted
+#   ^^^^^^^^^^^^^^ meta.string.unquoted
     This;Divides;Into;Five;Arguments
-#       ^ punctuation.separator.cmake
-#               ^ punctuation.separator.cmake
-#                    ^ punctuation.separator.cmake
-#                         ^ punctuation.separator.cmake
+#       ^ punctuation.separator
+#               ^ punctuation.separator
+#                    ^ punctuation.separator
+#                         ^ punctuation.separator
     Escaped\;Semicolon
-#   ^^^^^^^^^^^^^^^^^^ string.unquoted
+#   ^^^^^^^^^^^^^^^^^^ meta.string.unquoted
     )
   message("${arg}")
 endforeach()
@@ -271,13 +270,13 @@ add_custom_target(ClaraDeploy
     COMMAND
         ${CMAKE_COMMAND} 
             -D VERSION=${PROJECT_VERSION} 
-#              ^^^^^^^^ string.unquoted.cmake
+#              ^^^^^^^^ meta.string.unquoted
             -D SUBLIME_PLATFORM_EXT=${SUBLIME_PLATFORM_EXT} 
-#              ^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cmake
+#              ^^^^^^^^^^^^^^^^^^^^^ meta.string.unquoted
             -D ZIPFILE="${Clara_tar_output}" 
-#              ^^^^^^^^string.unquoted.cmake
-            -P "${CMAKE_CURRENT_SOURCE_DIR}/Deploy.cmake"
-#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.cmake
+#              ^^^^^^^^ meta.string.unquoted
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/Deploy"
+#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
     DEPENDS
         ClaraPackage
     COMMENT
@@ -290,14 +289,14 @@ exquisitaque doctrina "${philosophi}" Graeco sermone tractavissent, ea Latinis
 litteris mandaremus, fore ut hic noster labor in varias reprehensiones
 incurreret. [[ x ]] nam quibusdam, et iis quidem non admodum indoctis, totum hoc
 displicet philosophari. ]=])
-#^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ string.raw
 #                       ^^^ punctuation.definition.string.end
-#                          ^ punctuation.section.parens.end.cmake                                                                 
+#                          ^ punctuation.section.parens.end                                                                 
 
 set_target_properties(gintonic PROPERTIES CXX_STANDARD 14)
 #  ^ meta.function-call variable.function
-#                     ^ string.unquoted
+#                     ^ meta.string.unquoted
 #                              ^ variable.parameter
 #                                         ^ variable.parameter
-#                                                      ^ string.unquoted
+#                                                      ^ meta.string.unquoted
 

--- a/syntax_test.txt
+++ b/syntax_test.txt
@@ -63,9 +63,10 @@ message(STATUS "The some_var variable has the value \"${some_var}\"")
 #       ^^^^^^ variable.parameter 
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 #                                                   ^^ constant.character.escape
-#                                                     ^^ keyword.other.block.begin
+#                                                     ^ punctuation.definition.variable
+#                                                      ^ punctuation.section
+#                                                               ^ punctuation.section
 #                                                       ^^^^^^^^ meta.text-substitution
-#                                                               ^ keyword.other.block.end
 #                                                                ^^ constant.character.escape
 
 target_link_libraries(mytarget PUBLIC
@@ -76,10 +77,12 @@ target_link_libraries(mytarget PUBLIC
 
 set(asdf nested_vars_test some${var_inside_${anot${h}er_var}_and_moving_on}_even_further)
 #  ^ punctuation.section.parens.begin
-#                             ^^ keyword.other.block.begin
-#                                          ^^ keyword.other.block.begin
-#                                                          ^ keyword.other.block.end
-#                                                                         ^ keyword.other.block.end
+#                             ^ punctuation.definition.variable
+#                              ^ punctuation.section
+#                                          ^ punctuation.definition.variable
+#                                           ^ punctuation.section
+#                                                          ^ punctuation.section
+#                                                                         ^ punctuation.section
 
 set(some_list "one;two;thre\;e")
 #                 ^ punctuation.separator
@@ -118,7 +121,10 @@ if (NOT "${the_var}" MATCHES "[A-Za-z]\\d+")
 # maybe add regex as an embedded syntax here
 
 if ($ENV{LD_LIBRARY_PATH} STREQUAL /usr/local/lib)
-#   ^^^^^ keyword.other.block.begin
+#   ^ punctuation.definition.variable
+#    ^^^ keyword.operator.word
+#       ^ punctuation.section
+#                       ^ punctuation.section
 #                                  ^^^^^^^^^^^^^^ meta.string.unquoted
 endif()
 
@@ -172,8 +178,9 @@ set(LLVM_CONFIG_LIBRARY_DIRS "\${LLVM_INSTALL_PREFIX}/lib\${LLVM_LIBDIR_SUFFIX}"
 set(LLVM_CONFIG_CMAKE_DIR "\${LLVM_INSTALL_PREFIX}/${LLVM_INSTALL_PACKAGE_DIR}")
 #                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 #                          ^^ constant.character.escape
-#                                                  ^^ keyword.other.block.begin
-#                                                                            ^ keyword.other.block.end
+#                                                  ^ punctuation.definition.variable
+#                                                   ^ punctuation.section
+#                                                                            ^ punctuation.section
 set(LLVM_CONFIG_BINARY_DIR "\${LLVM_INSTALL_PREFIX}")
 set(LLVM_CONFIG_TOOLS_BINARY_DIR "\${LLVM_INSTALL_PREFIX}/bin")
 set(LLVM_CONFIG_EXPORTS_FILE "\${LLVM_CMAKE_DIR}/LLVMExports")
@@ -190,9 +197,10 @@ target_include_directories(module PUBLIC $<CMAKE_COMPILER_ID>)
 #                         ^ punctuation.section.parens.begin
 #                          ^^^^^^ meta.string.unquoted
 #                                 ^^^^^^ variable.parameter
-#                                        ^^ keyword.other.block.begin
+#                                        ^ punctuation.definition.variable
+#                                         ^ punctuation.section
 #                                          ^^^^^^^^^^^^^^^^^ meta.generator-expression
-#                                                           ^ keyword.other.block.end
+#                                                           ^ punctuation.section
 #                                                            ^ punctuation.section.parens.end
 
 
@@ -210,9 +218,10 @@ if(NOT (CMAKE_VERSION VERSION_LESS 3.0))  # CMake >= 3.0
   target_include_directories(module INTERFACE $<BUILD_INTERFACE:${PYBIND11_INCLUDE_DIR}>
 #                                               ^^^^^^^^^^^^^^^ variable
 #                                                              ^ punctuation.separator
-#                                                               ^^ keyword.other.block.begin
+#                                                               ^ punctuation.definition.variable
+#                                                                ^ punctuation.section
 #                                                                 ^^^^^^^^^^^^^^^^^^^^ variable
-#                                                                                     ^^ keyword.other.block.end
+#                                                                                     ^^ punctuation.section
                                               $<BUILD_INTERFACE:${PYTHON_INCLUDE_DIRS}>
                                               $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
   if(WIN32 OR CYGWIN)


### PR DESCRIPTION
This is the big one!

* Use `meta.string.unquoted` for unquoted strings, otherwise everything looks like a string! [improvement]
* Command invocations are case-insensitive, so `endif()` is the same as `EnDiF()`. This PR fixes that. [bugfix]
* Use `entity.name.function` for the first identifier in the `function(...)` command. [improvement]
* Use `entity.name.function` for the first identifier in the `macro(...)` command. [improvement]
* Highlight `include(...)` as `keyword.control.import`. [improvement]
* For substitutions `${..}`, we now use `punctuation.definition.variable` for the `$`, and `punctuation.section` for the braces `{}`. [improvement]
* For generator expressions `$<...>`, same thing as above. [improvement]

I try to follow the scope name guide: https://www.sublimetext.com/docs/3/scope_naming.html