### PR TITLE
Add simple snippet for every builtin command

### DIFF
--- a/Snippets/add_compile_options.sublime-snippet
+++ b/Snippets/add_compile_options.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_compile_options</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_compile_options($0)]]>	</content>
+</snippet>

--- a/Snippets/add_custom_command.sublime-snippet
+++ b/Snippets/add_custom_command.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_custom_command</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_custom_command($0)]]>	</content>
+</snippet>

--- a/Snippets/add_custom_target.sublime-snippet
+++ b/Snippets/add_custom_target.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_custom_target</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_custom_target($0)]]>	</content>
+</snippet>

--- a/Snippets/add_definitions.sublime-snippet
+++ b/Snippets/add_definitions.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_definitions</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_definitions($0)]]>	</content>
+</snippet>

--- a/Snippets/add_dependencies.sublime-snippet
+++ b/Snippets/add_dependencies.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_dependencies</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_dependencies($0)]]>	</content>
+</snippet>

--- a/Snippets/add_executable.sublime-snippet
+++ b/Snippets/add_executable.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_executable</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_executable($0)]]>	</content>
+</snippet>

--- a/Snippets/add_library.sublime-snippet
+++ b/Snippets/add_library.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_library</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_library($0)]]>	</content>
+</snippet>

--- a/Snippets/add_subdirectory.sublime-snippet
+++ b/Snippets/add_subdirectory.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_subdirectory</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_subdirectory($0)]]>	</content>
+</snippet>

--- a/Snippets/add_test.sublime-snippet
+++ b/Snippets/add_test.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>add_test</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[add_test($0)]]>	</content>
+</snippet>

--- a/Snippets/aux_source_directory.sublime-snippet
+++ b/Snippets/aux_source_directory.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>aux_source_directory</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[aux_source_directory($0)]]>	</content>
+</snippet>

--- a/Snippets/break.sublime-snippet
+++ b/Snippets/break.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>break</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[break($0)]]>	</content>
+</snippet>

--- a/Snippets/build_command.sublime-snippet
+++ b/Snippets/build_command.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<description>command</description>
+	<tabTrigger>build_command</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[build_command($0)]]>	</content>
+</snippet>

--- a/Snippets/build_name.sublime-snippet
+++ b/Snippets/build_name.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<description>command</description>
+	<tabTrigger>build_name</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[build_name($0)]]>	</content>
+</snippet>

--- a/Snippets/cmake_host_system_information.sublime-snippet
+++ b/Snippets/cmake_host_system_information.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<description>command</description>
+	<tabTrigger>cmake_host_system_information</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[cmake_host_system_information($0)]]>	</content>
+</snippet>

--- a/Snippets/cmake_parse_arguments.sublime-snippet
+++ b/Snippets/cmake_parse_arguments.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>cmake_parse_arguments</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[cmake_parse_arguments($0)]]>	</content>
+</snippet>

--- a/Snippets/cmake_policy.sublime-snippet
+++ b/Snippets/cmake_policy.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>cmake_policy</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[cmake_policy($0)]]>	</content>
+</snippet>

--- a/Snippets/configure_file.sublime-snippet
+++ b/Snippets/configure_file.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>configure_file</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[configure_file($0)]]>	</content>
+</snippet>

--- a/Snippets/continue.sublime-snippet
+++ b/Snippets/continue.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>continue</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[continue($0)]]>	</content>
+</snippet>

--- a/Snippets/create_test_sourcelist.sublime-snippet
+++ b/Snippets/create_test_sourcelist.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>create_test_sourcelist</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[create_test_sourcelist($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_build.sublime-snippet
+++ b/Snippets/ctest_build.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_build</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_build($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_configure.sublime-snippet
+++ b/Snippets/ctest_configure.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_configure</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_configure($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_coverage.sublime-snippet
+++ b/Snippets/ctest_coverage.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_coverage</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_coverage($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_empty_binary_directory.sublime-snippet
+++ b/Snippets/ctest_empty_binary_directory.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_empty_binary_directory</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_empty_binary_directory($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_memcheck.sublime-snippet
+++ b/Snippets/ctest_memcheck.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_memcheck</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_memcheck($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_read_custom_files.sublime-snippet
+++ b/Snippets/ctest_read_custom_files.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_read_custom_files</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_read_custom_files($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_run_script.sublime-snippet
+++ b/Snippets/ctest_run_script.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_run_script</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_run_script($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_sleep.sublime-snippet
+++ b/Snippets/ctest_sleep.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_sleep</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_sleep($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_start.sublime-snippet
+++ b/Snippets/ctest_start.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_start</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_start($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_submit.sublime-snippet
+++ b/Snippets/ctest_submit.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_submit</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_submit($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_test.sublime-snippet
+++ b/Snippets/ctest_test.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_test</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_test($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_update.sublime-snippet
+++ b/Snippets/ctest_update.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_update</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_update($0)]]>	</content>
+</snippet>

--- a/Snippets/ctest_upload.sublime-snippet
+++ b/Snippets/ctest_upload.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>ctest_upload</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[ctest_upload($0)]]>	</content>
+</snippet>

--- a/Snippets/define_property.sublime-snippet
+++ b/Snippets/define_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>define_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[define_property($0)]]>	</content>
+</snippet>

--- a/Snippets/else.sublime-snippet
+++ b/Snippets/else.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>else</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[else($0)]]>	</content>
+</snippet>

--- a/Snippets/elseif.sublime-snippet
+++ b/Snippets/elseif.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>elseif</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[elseif($0)]]>	</content>
+</snippet>

--- a/Snippets/enable_language.sublime-snippet
+++ b/Snippets/enable_language.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>enable_language</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[enable_language($0)]]>	</content>
+</snippet>

--- a/Snippets/enable_testing.sublime-snippet
+++ b/Snippets/enable_testing.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>enable_testing</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[enable_testing($0)]]>	</content>
+</snippet>

--- a/Snippets/endforeach.sublime-snippet
+++ b/Snippets/endforeach.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>endforeach</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[endforeach($0)]]>	</content>
+</snippet>

--- a/Snippets/endfunction.sublime-snippet
+++ b/Snippets/endfunction.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>endfunction</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[endfunction($0)]]>	</content>
+</snippet>

--- a/Snippets/endif.sublime-snippet
+++ b/Snippets/endif.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>endif</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[endif($0)]]>	</content>
+</snippet>

--- a/Snippets/endmacro.sublime-snippet
+++ b/Snippets/endmacro.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>endmacro</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[endmacro($0)]]>	</content>
+</snippet>

--- a/Snippets/endwhile.sublime-snippet
+++ b/Snippets/endwhile.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>endwhile</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[endwhile($0)]]>	</content>
+</snippet>

--- a/Snippets/exec_program.sublime-snippet
+++ b/Snippets/exec_program.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>exec_program</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[exec_program($0)]]>	</content>
+</snippet>

--- a/Snippets/execute_process.sublime-snippet
+++ b/Snippets/execute_process.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>execute_process</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[execute_process($0)]]>	</content>
+</snippet>

--- a/Snippets/export.sublime-snippet
+++ b/Snippets/export.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>export</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[export($0)]]>	</content>
+</snippet>

--- a/Snippets/export_library_dependencies.sublime-snippet
+++ b/Snippets/export_library_dependencies.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>export_library_dependencies</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[export_library_dependencies($0)]]>	</content>
+</snippet>

--- a/Snippets/file.sublime-snippet
+++ b/Snippets/file.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>file</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[file($0)]]>	</content>
+</snippet>

--- a/Snippets/find_file.sublime-snippet
+++ b/Snippets/find_file.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>find_file</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[find_file($0)]]>	</content>
+</snippet>

--- a/Snippets/find_library.sublime-snippet
+++ b/Snippets/find_library.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>find_library</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[find_library($0)]]>	</content>
+</snippet>

--- a/Snippets/find_package.sublime-snippet
+++ b/Snippets/find_package.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>find_package</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[find_package($0)]]>	</content>
+</snippet>

--- a/Snippets/find_path.sublime-snippet
+++ b/Snippets/find_path.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>find_path</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[find_path($0)]]>	</content>
+</snippet>

--- a/Snippets/find_program.sublime-snippet
+++ b/Snippets/find_program.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>find_program</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[find_program($0)]]>	</content>
+</snippet>

--- a/Snippets/fltk_wrap_ui.sublime-snippet
+++ b/Snippets/fltk_wrap_ui.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>fltk_wrap_ui</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[fltk_wrap_ui($0)]]>	</content>
+</snippet>

--- a/Snippets/function.sublime-snippet
+++ b/Snippets/function.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>function</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[function($0)]]>	</content>
+</snippet>

--- a/Snippets/get_cmake_property.sublime-snippet
+++ b/Snippets/get_cmake_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>get_cmake_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[get_cmake_property($0)]]>	</content>
+</snippet>

--- a/Snippets/get_directory_property.sublime-snippet
+++ b/Snippets/get_directory_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>get_directory_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[get_directory_property($0)]]>	</content>
+</snippet>

--- a/Snippets/get_filename_component.sublime-snippet
+++ b/Snippets/get_filename_component.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>get_filename_component</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[get_filename_component($0)]]>	</content>
+</snippet>

--- a/Snippets/get_property.sublime-snippet
+++ b/Snippets/get_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>get_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[get_property($0)]]>	</content>
+</snippet>

--- a/Snippets/get_source_file_property.sublime-snippet
+++ b/Snippets/get_source_file_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>get_source_file_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[get_source_file_property($0)]]>	</content>
+</snippet>

--- a/Snippets/get_target_property.sublime-snippet
+++ b/Snippets/get_target_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>get_target_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[get_target_property($0)]]>	</content>
+</snippet>

--- a/Snippets/get_test_property.sublime-snippet
+++ b/Snippets/get_test_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>get_test_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[get_test_property($0)]]>	</content>
+</snippet>

--- a/Snippets/include.sublime-snippet
+++ b/Snippets/include.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>include</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[include($0)]]>	</content>
+</snippet>

--- a/Snippets/include_directories.sublime-snippet
+++ b/Snippets/include_directories.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>include_directories</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[include_directories($0)]]>	</content>
+</snippet>

--- a/Snippets/include_external_msproject.sublime-snippet
+++ b/Snippets/include_external_msproject.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>include_external_msproject</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[include_external_msproject($0)]]>	</content>
+</snippet>

--- a/Snippets/include_regular_expression.sublime-snippet
+++ b/Snippets/include_regular_expression.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>include_regular_expression</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[include_regular_expression($0)]]>	</content>
+</snippet>

--- a/Snippets/install.sublime-snippet
+++ b/Snippets/install.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>install</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[install($0)]]>	</content>
+</snippet>

--- a/Snippets/install_files.sublime-snippet
+++ b/Snippets/install_files.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>install_files</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[install_files($0)]]>	</content>
+</snippet>

--- a/Snippets/install_programs.sublime-snippet
+++ b/Snippets/install_programs.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>install_programs</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[install_programs($0)]]>	</content>
+</snippet>

--- a/Snippets/install_targets.sublime-snippet
+++ b/Snippets/install_targets.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>install_targets</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[install_targets($0)]]>	</content>
+</snippet>

--- a/Snippets/link_directories.sublime-snippet
+++ b/Snippets/link_directories.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>link_directories</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[link_directories($0)]]>	</content>
+</snippet>

--- a/Snippets/link_libraries.sublime-snippet
+++ b/Snippets/link_libraries.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>link_libraries</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[link_libraries($0)]]>	</content>
+</snippet>

--- a/Snippets/list.sublime-snippet
+++ b/Snippets/list.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>list</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[list($0)]]>	</content>
+</snippet>

--- a/Snippets/load_cache.sublime-snippet
+++ b/Snippets/load_cache.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>load_cache</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[load_cache($0)]]>	</content>
+</snippet>

--- a/Snippets/load_command.sublime-snippet
+++ b/Snippets/load_command.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>load_command</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[load_command($0)]]>	</content>
+</snippet>

--- a/Snippets/macro.sublime-snippet
+++ b/Snippets/macro.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>macro</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[macro($0)]]>	</content>
+</snippet>

--- a/Snippets/make_directory.sublime-snippet
+++ b/Snippets/make_directory.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>make_directory</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[make_directory($0)]]>	</content>
+</snippet>

--- a/Snippets/mark_as_advanced.sublime-snippet
+++ b/Snippets/mark_as_advanced.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>mark_as_advanced</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[mark_as_advanced($0)]]>	</content>
+</snippet>

--- a/Snippets/math.sublime-snippet
+++ b/Snippets/math.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>math</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[math($0)]]>	</content>
+</snippet>

--- a/Snippets/message.sublime-snippet
+++ b/Snippets/message.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>message</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[message($0)]]>	</content>
+</snippet>

--- a/Snippets/output_required_files.sublime-snippet
+++ b/Snippets/output_required_files.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>output_required_files</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[output_required_files($0)]]>	</content>
+</snippet>

--- a/Snippets/qt_wrap_cpp.sublime-snippet
+++ b/Snippets/qt_wrap_cpp.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>qt_wrap_cpp</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[qt_wrap_cpp($0)]]>	</content>
+</snippet>

--- a/Snippets/qt_wrap_ui.sublime-snippet
+++ b/Snippets/qt_wrap_ui.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>qt_wrap_ui</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[qt_wrap_ui($0)]]>	</content>
+</snippet>

--- a/Snippets/remove.sublime-snippet
+++ b/Snippets/remove.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>remove</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[remove($0)]]>	</content>
+</snippet>

--- a/Snippets/remove_definitions.sublime-snippet
+++ b/Snippets/remove_definitions.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>remove_definitions</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[remove_definitions($0)]]>	</content>
+</snippet>

--- a/Snippets/return.sublime-snippet
+++ b/Snippets/return.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>return</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[return($0)]]>	</content>
+</snippet>

--- a/Snippets/separate_arguments.sublime-snippet
+++ b/Snippets/separate_arguments.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>separate_arguments</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[separate_arguments($0)]]>	</content>
+</snippet>

--- a/Snippets/set_directory_properties.sublime-snippet
+++ b/Snippets/set_directory_properties.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>set_directory_properties</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[set_directory_properties($0)]]>	</content>
+</snippet>

--- a/Snippets/set_property.sublime-snippet
+++ b/Snippets/set_property.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>set_property</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[set_property($0)]]>	</content>
+</snippet>

--- a/Snippets/set_source_files_properties.sublime-snippet
+++ b/Snippets/set_source_files_properties.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>set_source_files_properties</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[set_source_files_properties($0)]]>	</content>
+</snippet>

--- a/Snippets/set_target_properties.sublime-snippet
+++ b/Snippets/set_target_properties.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>set_target_properties</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[set_target_properties($0)]]>	</content>
+</snippet>

--- a/Snippets/set_tests_properties.sublime-snippet
+++ b/Snippets/set_tests_properties.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>set_tests_properties</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[set_tests_properties($0)]]>	</content>
+</snippet>

--- a/Snippets/site_name.sublime-snippet
+++ b/Snippets/site_name.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>site_name</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[site_name($0)]]>	</content>
+</snippet>

--- a/Snippets/source_group.sublime-snippet
+++ b/Snippets/source_group.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>source_group</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[source_group($0)]]>	</content>
+</snippet>

--- a/Snippets/string.sublime-snippet
+++ b/Snippets/string.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>string</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[string($0)]]>	</content>
+</snippet>

--- a/Snippets/subdir_depends.sublime-snippet
+++ b/Snippets/subdir_depends.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>subdir_depends</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[subdir_depends($0)]]>	</content>
+</snippet>

--- a/Snippets/subdirs.sublime-snippet
+++ b/Snippets/subdirs.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>subdirs</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[subdirs($0)]]>	</content>
+</snippet>

--- a/Snippets/target_compile_definitions.sublime-snippet
+++ b/Snippets/target_compile_definitions.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>target_compile_definitions</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[target_compile_definitions($0)]]>	</content>
+</snippet>

--- a/Snippets/target_compile_features.sublime-snippet
+++ b/Snippets/target_compile_features.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>target_compile_features</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[target_compile_features($0)]]>	</content>
+</snippet>

--- a/Snippets/target_compile_options.sublime-snippet
+++ b/Snippets/target_compile_options.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>target_compile_options</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[target_compile_options($0)]]>	</content>
+</snippet>

--- a/Snippets/target_include_directories.sublime-snippet
+++ b/Snippets/target_include_directories.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>target_include_directories</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[target_include_directories($0)]]>	</content>
+</snippet>

--- a/Snippets/target_link_libraries.sublime-snippet
+++ b/Snippets/target_link_libraries.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>target_link_libraries</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[target_link_libraries($0)]]>	</content>
+</snippet>

--- a/Snippets/target_sources.sublime-snippet
+++ b/Snippets/target_sources.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>target_sources</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[target_sources($0)]]>	</content>
+</snippet>

--- a/Snippets/try_compile.sublime-snippet
+++ b/Snippets/try_compile.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>try_compile</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[try_compile($0)]]>	</content>
+</snippet>

--- a/Snippets/try_run.sublime-snippet
+++ b/Snippets/try_run.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>try_run</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[try_run($0)]]>	</content>
+</snippet>

--- a/Snippets/unset.sublime-snippet
+++ b/Snippets/unset.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>unset</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[unset($0)]]>	</content>
+</snippet>

--- a/Snippets/use_mangled_mesa.sublime-snippet
+++ b/Snippets/use_mangled_mesa.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>use_mangled_mesa</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[use_mangled_mesa($0)]]>	</content>
+</snippet>

--- a/Snippets/utility_source.sublime-snippet
+++ b/Snippets/utility_source.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>utility_source</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[utility_source($0)]]>	</content>
+</snippet>

--- a/Snippets/variable_requires.sublime-snippet
+++ b/Snippets/variable_requires.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>variable_requires</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[variable_requires($0)]]>	</content>
+</snippet>

--- a/Snippets/variable_watch.sublime-snippet
+++ b/Snippets/variable_watch.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>variable_watch</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[variable_watch($0)]]>	</content>
+</snippet>

--- a/Snippets/write_file.sublime-snippet
+++ b/Snippets/write_file.sublime-snippet
@@ -1,0 +1,8 @@
+
+<snippet>
+	<description>command</description>
+	<tabTrigger>write_file</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+	<content>
+<![CDATA[write_file($0)]]>	</content>
+</snippet>

--- a/tools/parse-snippets.py
+++ b/tools/parse-snippets.py
@@ -1,0 +1,36 @@
+import subprocess
+import dicttoxml  # pip install dicttoxml
+import os
+from xml.dom.minidom import parseString
+
+def main():
+    commands = subprocess.check_output(["cmake", "--help-command-list"]) \
+                         .decode("utf-8")                                \
+                         .splitlines()
+    existing_snippets = [ os.path.splitext(f)[0] for f in os.listdir("Snippets") ]
+    new_commands = set(commands) - set(existing_snippets)
+    if not new_commands:
+        print("No new commands.")
+        return
+    for cmd in new_commands:
+        print("New command:", cmd)
+        xml1 = dicttoxml.dicttoxml({ 
+            "description": "command", 
+            "tabTrigger": cmd, 
+            "scope": "source.cmake - meta.function-call.arguments - string - comment"},
+            attr_type=False,
+            root=False)
+        xml2 = dicttoxml.dicttoxml({ 
+            "content": cmd + "($0)" }, 
+            attr_type=False, 
+            cdata=True, 
+            root=False)
+        xml = b"<snippet>" + xml1 + xml2 + b"</snippet>"
+        xml = parseString(xml).toprettyxml()
+        xml = xml[len('<?xml version="1.0"?>') + 2:] # terrible hack, but works
+        with open(os.path.join("Snippets", cmd + ".sublime-snippet"), "w") as f:
+            f.write(xml)
+    return 0
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
This PR adds a basic snippet for *every* builtin command.

The way this is generated is by using the tools/parse-snippets.py python3 script. It's supposed to be run from the Sublime-CMakeLists folder, e.g. `python3 tools/parse-snippets.py`. Existing snippets are not overwritten.

You need the dicttoxml library in order to run tools/parse-snippets.py.