### PR TITLE
Account for syntax being none in some cases

### DIFF
--- a/AutoComplete.py
+++ b/AutoComplete.py
@@ -6,7 +6,12 @@ class AutoComplete(sublime_plugin.ViewEventListener):
 
     @classmethod
     def is_applicable(cls, settings):
-        return settings.get("syntax", "").endswith("CMake.sublime-syntax")
+        if not settings:
+            return False
+        syntax = settings.get("syntax", None)
+        if not syntax:
+            return False
+        return syntax.endswith("CMake.sublime-syntax")
 
     def on_query_completions(self, prefix, locations):
         for point in locations:


### PR DESCRIPTION
In some cases, the settings object or the syntax may be None. We check for
those cases now and just return False ("not applicable").