### PR TITLE
Escape '-' in character class

### DIFF
--- a/CMake.sublime-syntax
+++ b/CMake.sublime-syntax
@@ -12,7 +12,7 @@ variables:
   unquoted_argument_element: "[^ \t()#\"\\']"
   unquoted_argument: "{{unquoted_argument_element}}+"
   identifier: \b[[:alpha:]_][[:alnum:]_]*\b
-  generic_named_parameter: \b@?[A-Z_][A-Z0-9_]*(?=[^\w-<>=\$])
+  generic_named_parameter: \b@?[A-Z_][A-Z0-9_]*(?=[^\w\-<>=\$])
 #-------------------------------------------------------------------------------
 contexts:
   prototype:


### PR DESCRIPTION
The `generic_named_parameter` regex causes problems in [syntect](https://github.com/trishume/syntect), a library that uses Sublime Text syntax files.   Unfortunately, it uses a slightly different regex engine than Sublime Text and is not always 100% compatible. Escaping the `-` in the character class resolves this problem.