### PR TITLE
Do not zip the test files for package control

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+syntax_test.txt export-ignore
+syntax_test_.h.in export-ignore
+syntax_test_.hpp.in export-ignore


### PR DESCRIPTION
This ensures that once a release is made, git will not zip along these files for the CMake.sublime-package file.