### PR TITLE
add snippet to enable testing

### DIFF
--- a/Snippets/enable_testing.sublime-snippet
+++ b/Snippets/enable_testing.sublime-snippet
@@ -1,8 +1,6 @@
 <snippet>
 	<description>builtin</description>
-	<content><![CDATA[enable_testing()
-
-]]></content>
+	<content><![CDATA[enable_testing()]]></content>
 	<tabTrigger>enable_testing</tabTrigger>
 	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>

--- a/Snippets/enable_testing.sublime-snippet
+++ b/Snippets/enable_testing.sublime-snippet
@@ -1,0 +1,7 @@
+<snippet>
+	<description>builtin</description>
+	<content><![CDATA[enable_testing()
+$0]]></content>
+	<tabTrigger>enable_testing</tabTrigger>
+	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
+</snippet>

--- a/Snippets/enable_testing.sublime-snippet
+++ b/Snippets/enable_testing.sublime-snippet
@@ -1,7 +1,8 @@
 <snippet>
 	<description>builtin</description>
 	<content><![CDATA[enable_testing()
-$0]]></content>
+
+]]></content>
 	<tabTrigger>enable_testing</tabTrigger>
 	<scope>source.cmake - meta.function-call.arguments - string - comment</scope>
 </snippet>


### PR DESCRIPTION
this PR improves snippet to enable testing

before: autocomplete adds `enable_testing()`, leaving the cursor inside brackets. This is annoying, the function has no arguments.

after: autocomplete adds `enable_testing()` and a line break. If the new line is too intrusive i can remove it, but i always have this command in a single line for readability. 

as far as i can see the tool automatically skips new snippets on generation, so we don't have any duplicates?