### PR TITLE
remove repeated arguments in control flow

### DIFF
--- a/Snippets/foreach.sublime-snippet
+++ b/Snippets/foreach.sublime-snippet
@@ -2,7 +2,7 @@
 	<description>control flow</description>
 	<content><![CDATA[foreach(${1:item} ${2:items})
 	$0
-endforeach(${1:item})]]></content>
+endforeach()]]></content>
 	<tabTrigger>foreach</tabTrigger>
 	<scope>source.cmake - meta.function-call.arguments - variable.other.readwrite.cmake - string - comment</scope>
 </snippet>

--- a/Snippets/if.sublime-snippet
+++ b/Snippets/if.sublime-snippet
@@ -2,7 +2,7 @@
 	<description>control flow</description>
 	<content><![CDATA[if(${1:predicate})
 	$0
-endif(${1:predicate})]]></content>
+endif()]]></content>
 	<tabTrigger>if</tabTrigger>
 	<scope>source.cmake - meta.function-call.arguments - variable.other.readwrite.cmake - string - comment</scope>
 </snippet>


### PR DESCRIPTION
this PR removes repeated arguments in the endif, endforeach clauses. This is no longer required since CMake 2.8