### PR TITLE
Fix incorrect comment matching in generator expressions

### DIFF
--- a/CMake.sublime-syntax
+++ b/CMake.sublime-syntax
@@ -629,7 +629,8 @@ contexts:
           set:
             - meta_content_scope: meta.generator-expression.cmake
             - include: generator-expression-common
-            - include: prototype
+            - include: variable-substitution
+            - include: generator-expression
         - include: prototype
 
   generator-expression-common:

--- a/syntax_test_cmake.txt
+++ b/syntax_test_cmake.txt
@@ -361,6 +361,15 @@ foreach(iexample RANGE ${nexample})
 endforeach()
 # <- meta.group.foreach.cmake meta.function-call.cmake keyword.control.endforeach.cmake
 
+file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}${configsubdir}/foo.hpp"
+    CONTENT "
+        $<$<BOOL:Python_FOUND>:#define PYTHON_IS_PRESENT>
+        #                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line
+    "
+)
+# <- - string.quoted
+
 test_nested_conditions(Abc CONDITION GCC AND (arch STREQUAL "x") COMPILE_OPTIONS -fno)
 # ^^^^^^^^^^^^^^^^^^^^ meta.function-call.generic.cmake variable.function.generic
 #                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.generic


### PR DESCRIPTION
It's possible to have a `#` character in generator expressions. For example, to write a C preprocessor line like `#define FOOBAR`. The syntax incorrectly parsed that as the start of a comment. This change fixes that.